### PR TITLE
Fixed: Typo in name of 'extension' prop

### DIFF
--- a/types/index.d.cts
+++ b/types/index.d.cts
@@ -9,7 +9,7 @@ declare namespace phoneFns {
     areaCode: string;
     localCode: string;
     lineNumber: string;
-    extention: string;
+    extension: string;
   }
 
   interface Static {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -9,7 +9,7 @@ declare namespace phoneFns {
     areaCode: string;
     localCode: string;
     lineNumber: string;
-    extention: string;
+    extension: string;
   }
 
   interface Static {
@@ -32,7 +32,7 @@ declare namespace phoneFns {
     /**
      * Strips all of the special characters from the given string
      */
-    uglify(phone: string|number): string;
+    uglify(phone: string | number): string;
   }
 }
 


### PR DESCRIPTION
## :page_facing_up: Description

> Short summary of the change

## :squid: Type of Change

- [X] Bug Fix
- [ ] Chore
- [ ] New Feature
- [ ] Breaking Change

## :clipboard: PR Checklist
[//]: # (Fill this out if you're adding a new feature if something isn't applicable, just check it)

- [X] This pull request has a descriptive title and information useful to a reviewer.
- [X] All tests are passing
- [ ] Changelog Updated Properly
- [X] Types updated/added as needed
- [ ] Has new/updated tests


## :memo: Changes

[//]: # (Please delete any sections you do not use)
### :rotating_light: Breaking Changes

None

### :nail_care: New

None

### :confetti_ball: Enhanced

None

### :wrench: Fixed

- Type definitions updated to resolve typo in Breakdown type that prevented the 'extension' attribute from being visible.